### PR TITLE
Catch JSON parse errors and propagate the exception

### DIFF
--- a/mandrill.js
+++ b/mandrill.js
@@ -36,7 +36,11 @@ function makeMandrill(key)
                     //everything is good!
                     if (format == 'json')
                     {
-                        body = JSON.parse(body);
+                        try {
+                            body = JSON.parse(body);
+                        } catch (e) {
+                            callback(e);
+                        }
                     }
 
                     if (response['statusCode'] >= 200 && response['statusCode'] < 300)


### PR DESCRIPTION
Issues upstream with the Mandrill API can cause a bad response body which will cause a crash when parsing is attempted.  This change catches and propagates any JSON parse errors.
