### PR TITLE
Use requestretry instead of request because sometimes recoverable errors...

### DIFF
--- a/mandrill.js
+++ b/mandrill.js
@@ -1,7 +1,7 @@
-var request = require('request'),
+var request = require('requestretry'),
     _ = require('underscore');
 
-var MANDRILL_API_ROOT = 'https://mandrillapp.com/api/1.0/'; 
+var MANDRILL_API_ROOT = 'https://mandrillapp.com/api/1.0/';
 
 function makeMandrill(key)
 {
@@ -23,6 +23,10 @@ function makeMandrill(key)
         var requestOptions = {
             method: 'POST',
             url: MANDRILL_API_ROOT + path + '.' + format,
+
+            // The above parameters are specific to Request-retry:
+            maxAttempts: 4,   // try 4 times
+            retryDelay: 1000  // wait for 1s before trying again
         };
 
         requestOptions['body'] = JSON.stringify( _.extend({ key: key }, opts) );

--- a/package.json
+++ b/package.json
@@ -1,24 +1,33 @@
 {
-    "name" : "node-mandrill",
-    "version" : "1.0.1",
-    "description" : "A node.js wrapper for MailChimp's Mandrill API.",
-    "author" : "Jim Rubenstein <jrubenstein@gmail.com> (http://twitter.com/jim_rubenstein)",
-    "main" : "mandrill.js",
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/jimrubenstein/node-mandrill.git"
-    },
-    "bugs": {
-        "url": "https://github.com/jimrubenstein/node-mandrill/issues"
-    },    
-    "engines": {
-        "node": ">= 0.8.2"
-    },
-    "dependencies": {
-        "request": ">= 2.9.100",
-        "underscore": ">= 1.3.3"
-    },    
-    "homepage":  "http://github.com/jimrubenstein/node-mandrill.git",
-    "keywords": ["mandrill", "node mandrill", "mandrill api", "email", "send email", "email api", "mailchimp", "mailchimp api", "email mailchimp"]
+  "name": "node-mandrill",
+  "version": "1.0.1",
+  "description": "A node.js wrapper for MailChimp's Mandrill API.",
+  "author": "Jim Rubenstein <jrubenstein@gmail.com> (http://twitter.com/jim_rubenstein)",
+  "main": "mandrill.js",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/jimrubenstein/node-mandrill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jimrubenstein/node-mandrill/issues"
+  },
+  "engines": {
+    "node": ">= 0.8.2"
+  },
+  "dependencies": {
+    "underscore": ">= 1.3.3",
+    "requestretry": "~1.0.1"
+  },
+  "homepage": "http://github.com/jimrubenstein/node-mandrill.git",
+  "keywords": [
+    "mandrill",
+    "node mandrill",
+    "mandrill api",
+    "email",
+    "send email",
+    "email api",
+    "mailchimp",
+    "mailchimp api",
+    "email mailchimp"
+  ]
 }
-


### PR DESCRIPTION
Use requestretry because sometimes recoverable errors (like `{"code":"ENOTFOUND","errno":"ENOTFOUND","syscall":"getaddrinfo"}`) can happen.
