### PR TITLE
Don't double-callback when mandrill returns an error

### DIFF
--- a/mandrill.js
+++ b/mandrill.js
@@ -39,7 +39,7 @@ function makeMandrill(key)
                         try {
                             body = JSON.parse(body);
                         } catch (e) {
-                            callback(e);
+                            return callback(e);
                         }
                     }
 


### PR DESCRIPTION
Mandrill timed out during one of our requests with the following body:

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```

node-mandrill properly caught the invalid JSON, but called the callback twice (once on line 42, once later on line 52) and caused a crash.
